### PR TITLE
Changing SDK 0.12 link

### DIFF
--- a/json/roadmap.json
+++ b/json/roadmap.json
@@ -222,7 +222,7 @@
       "span": 3,
       "date": "",
       "notes": "Please read the spec for more details.",
-      "url": "https://github.com/cosmos/cosmos-sdk/projects/4"
+      "url": "https://github.com/cosmos/cosmos-sdk/releases"
     },
     {
       "id": "sdk-1-0",


### PR DESCRIPTION
Changed to https://github.com/cosmos/cosmos-sdk/releases instead of this https://github.com/cosmos/cosmos-sdk/projects/4.
The link to the project was confusing people.