### PR TITLE
Update glossary.json

### DIFF
--- a/json/glossary.json
+++ b/json/glossary.json
@@ -80,13 +80,13 @@
   {
     "id": "finite-field",
     "title": "Finite Field",
-    "body": "A finite field is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "gf-2-255-19",
     "title": "GF(2^255-19)",
-    "body": "This is...",
+    "body": "",
     "url": ""
   },
   {
@@ -104,7 +104,7 @@
   {
     "id": "hub",
     "title": "Hub",
-    "body": "A Cosmos Hub is...",
+    "body": "",
     "url": ""
   },
   {
@@ -140,19 +140,19 @@
   {
     "id": "signature",
     "title": "Signature",
-    "body": "A signature is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "sharding",
     "title": "Sharding",
-    "body": "Sharding is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "stake",
     "title": "Stake",
-    "body": "Stake is...",
+    "body": "",
     "url": ""
   },
   {
@@ -164,31 +164,31 @@
   {
     "id": "testnet",
     "title": "Testnet",
-    "body": "Testnets are...",
+    "body": "",
     "url": ""
   },
   {
     "id": "token",
     "title": "Token",
-    "body": "A Cosmos Token is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "validator",
     "title": "Validator",
-    "body": "A Cosmos Validator is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "validator-set",
     "title": "Validator Set",
-    "body": "A Validator Set is...",
+    "body": "",
     "url": ""
   },
   {
     "id": "zksnark",
     "title": "zkSNARK",
-    "body": "zkSNARKs are...",
+    "body": "",
     "url": ""
   },
   {


### PR DESCRIPTION
remove empty body fields so that the build-from-the-json-file for the cosmos academy doesn't render empty glossary items. This is the line of code that requires this change: https://github.com/cosmos/cosmos-academy/pull/32/files#diff-85987f48f1258d9ee486e3191495582dR183

![screenshot from 2018-04-21 16-11-19](https://user-images.githubusercontent.com/8304391/39088366-a75e8f3a-457e-11e8-90cb-4f30b9820eba.png)