### PR TITLE
Rename Voyager Dev -> JS Dev

### DIFF
--- a/md/careers/technical-senior-software-engineer-voyager.md
+++ b/md/careers/technical-senior-software-engineer-voyager.md
@@ -1,4 +1,4 @@
-# Senior Software Engineer, JS
+# Senior Software Engineer, JavaScript
 
 ### This is a full time position and is located in either Berlin, Toronto, Berkeley, or San Francisco.
 

--- a/md/careers/technical-senior-software-engineer-voyager.md
+++ b/md/careers/technical-senior-software-engineer-voyager.md
@@ -1,8 +1,9 @@
-# Senior Software Engineer, Voyager
+# Senior Software Engineer, JS
 
 ### This is a full time position and is located in either Berlin, Toronto, Berkeley, or San Francisco.
 
 ### We're looking for someone who has:
+
 * At least 5 years of software engineering experience.
 * Significant experience writing JavaScript.
 * Knowledge of Vue.js or other reactive frameworks.
@@ -15,6 +16,7 @@
 * An eye for good UI and UX design.
 
 ### What your primary responsibilities will be:
+
 * Work with the Voyager team to triage issues and move the [project](https://github.com/cosmos/voyager/projects) forward.
 * Improve the Voyager codebase by committing DRY, well tested code.
 * Research, design, and implement features and optimizations.


### PR DESCRIPTION
There are a lot of quality JS engineers who would love to apply to our team. I think naming the role as Voyager Developer is doing ourselves a disservice. 