### PR TITLE
Add mint ABCI app to the ecosystem

### DIFF
--- a/json/ecosystem.json
+++ b/json/ecosystem.json
@@ -111,6 +111,13 @@
       "language": "Python",
       "author": "BigchainDB GmbH and the BigchainDB community",
       "description": "Blockchain database"
+    },
+    {
+      "name": "Mint",
+      "url": "https://github.com/Hashnode/mint",
+      "language": "Go",
+      "author": "Hashnode",
+      "description": "Build blockchain-powered social apps"
     }
   ],
   "abciServers": [


### PR DESCRIPTION
I created an ABCI app that helps people build blockchain-powered social apps easily.

- Code: https://github.com/Hashnode/mint
- Website: https://uphack.co
- Article: https://medium.freecodecamp.org/a-comprehensive-guide-to-coding-a-blockchain-powered-online-community-f938792dbcb4